### PR TITLE
Terminate buffer tool gracefully instead of killing

### DIFF
--- a/src/buffer.go
+++ b/src/buffer.go
@@ -1113,7 +1113,7 @@ func thirdPartyBuffer(streamID int, playlistID string, useBackup bool, backupNum
 			}
 
 			if !clientConnection(stream) {
-				cmd.Process.Kill()
+				terminateProcessGracefully(cmd)
 				f.Close()
 				cmd.Wait()
 				return


### PR DESCRIPTION
Killing is alright but I hijacked the buffer tool to use a wrapper script around vlc that leaves zombie process because it's killed and not terminated gracefully when client connection is gone.
I tested and had no negative impact.