### PR TITLE
[FIX] User-agent was not used to get M3U file.

### DIFF
--- a/src/provider.go
+++ b/src/provider.go
@@ -341,7 +341,14 @@ func downloadFileFromServer(providerURL string, proxyUrl string) (filename strin
 		}
 	}
 
-	resp, err := httpClient.Get(providerURL)
+	req, err := http.NewRequest("GET", providerURL, nil)
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("User-Agent", Settings.UserAgent)
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
I saw with wireshark that the user-agent is not used to get the Original M3u.
With this patch it does. 