### PR TITLE
Update data.go

### DIFF
--- a/src/data.go
+++ b/src/data.go
@@ -964,7 +964,13 @@ func buildDatabaseDVR() (err error) {
 	sort.Strings(Data.Playlist.M3U.Groups.Text)
 	sort.Strings(Data.Playlist.M3U.Groups.Value)
 
-	if len(Data.Streams.Active) == 0 && len(Data.Streams.All) <= System.UnfilteredChannelLimit && len(Settings.Filter) == 0 {
+        // Changes ChannelLimit to allow more channels if the player/client is not Plex (Restricted to 480 Channels Max)
+        var ChannelLimit = System.PlexChannelLimit
+        if !Settings.PlexPlayer{
+               ChannelLimit = System.UnfilteredChannelLimit
+           }
+
+        if len(Data.Streams.Active) == 0 && len(Data.Streams.All) <= ChannelLimit && len(Settings.Filter) == 0 {
 		Data.Streams.Active = Data.Streams.All
 		Data.Streams.Inactive = make([]interface{}, 0)
 


### PR DESCRIPTION
Change in code to use the new setting and allow to have a bigger than 480 channel list if not using a Plex Client, is set to max 999 for performance considerations. I didn't modified the settings UI for this new setting, it can be done (I don't know how) but still it'll require to restart the server to apply it.