### PR TITLE
Adds new settings to manage playlist limits depending on the Type of client, fixes on auth to download m3u/xml

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -54,7 +54,7 @@ func Init() (err error) {
 	System.ServerProtocol.WEB = "http"
 	System.ServerProtocol.XML = "http"
 	System.PlexChannelLimit = 480
-	System.UnfilteredChannelLimit = 480
+	System.UnfilteredChannelLimit = 999
 	System.Compatibility = "0.1.0"
 
 	// FFmpeg Default Einstellungen

--- a/src/data.go
+++ b/src/data.go
@@ -964,7 +964,13 @@ func buildDatabaseDVR() (err error) {
 	sort.Strings(Data.Playlist.M3U.Groups.Text)
 	sort.Strings(Data.Playlist.M3U.Groups.Value)
 
-	if len(Data.Streams.Active) == 0 && len(Data.Streams.All) <= System.UnfilteredChannelLimit && len(Settings.Filter) == 0 {
+        // Changes ChannelLimit to allow more channels if the player/client is not Plex (Restricted to 480 Channels Max)
+        var ChannelLimit = System.PlexChannelLimit
+        if !Settings.PlexPlayer{
+               ChannelLimit = System.UnfilteredChannelLimit
+           }
+
+        if len(Data.Streams.Active) == 0 && len(Data.Streams.All) <= ChannelLimit && len(Settings.Filter) == 0 {
 		Data.Streams.Active = Data.Streams.All
 		Data.Streams.Inactive = make([]interface{}, 0)
 

--- a/src/data.go
+++ b/src/data.go
@@ -799,9 +799,19 @@ func buildDatabaseDVR() (err error) {
 
 	System.ScanInProgress = 1
 
-	Data.Streams.All = make([]interface{}, 0, System.UnfilteredChannelLimit)
+        // Changes ChannelLimit to allow more channels if the player/client is not Plex (Restricted to 480 Channels Max)
+        var ChannelLimit = System.PlexChannelLimit
+        if !Settings.PlexPlayer{
+               ChannelLimit = Settings.SystemChannelLimit
+           }
+
+
+/*	Data.Streams.All = make([]interface{}, 0, System.UnfilteredChannelLimit)
 	Data.Streams.Active = make([]interface{}, 0, System.UnfilteredChannelLimit)
-	Data.Streams.Inactive = make([]interface{}, 0, System.UnfilteredChannelLimit)
+	Data.Streams.Inactive = make([]interface{}, 0, System.UnfilteredChannelLimit)*/
+        Data.Streams.All = make([]interface{}, 0, ChannelLimit)
+        Data.Streams.Active = make([]interface{}, 0, ChannelLimit)
+        Data.Streams.Inactive = make([]interface{}, 0, ChannelLimit)
 	Data.Playlist.M3U.Groups.Text = []string{}
 	Data.Playlist.M3U.Groups.Value = []string{}
 	Data.StreamPreviewUI.Active = []string{}
@@ -965,10 +975,12 @@ func buildDatabaseDVR() (err error) {
 	sort.Strings(Data.Playlist.M3U.Groups.Value)
 
         // Changes ChannelLimit to allow more channels if the player/client is not Plex (Restricted to 480 Channels Max)
-        var ChannelLimit = System.PlexChannelLimit
+/*        var ChannelLimit = System.PlexChannelLimit
         if !Settings.PlexPlayer{
                ChannelLimit = Settings.SystemChannelLimit
            }
+	// modified because I didn't knew the System.UnfilteredChannelLimit was used earlier in the procedure...
+*/
 
         if len(Data.Streams.Active) == 0 && len(Data.Streams.All) <= ChannelLimit && len(Settings.Filter) == 0 {
 		Data.Streams.Active = Data.Streams.All

--- a/src/data.go
+++ b/src/data.go
@@ -967,7 +967,7 @@ func buildDatabaseDVR() (err error) {
         // Changes ChannelLimit to allow more channels if the player/client is not Plex (Restricted to 480 Channels Max)
         var ChannelLimit = System.PlexChannelLimit
         if !Settings.PlexPlayer{
-               ChannelLimit = System.UnfilteredChannelLimit
+               ChannelLimit = Settings.SystemChannelLimit
            }
 
         if len(Data.Streams.Active) == 0 && len(Data.Streams.All) <= ChannelLimit && len(Settings.Filter) == 0 {

--- a/src/struct-system.go
+++ b/src/struct-system.go
@@ -339,6 +339,7 @@ type SettingsStruct struct {
 	Dummy                     bool                  `json:"dummy"`
 	DummyChannel              string                `json:"dummyChannel"`
 	IgnoreFilters             bool                  `json:"ignoreFilters"`
+        PlexPlayer                bool                  `json:"plexPlayer"`	
 }
 
 // LanguageUI : Sprache für das WebUI

--- a/src/struct-system.go
+++ b/src/struct-system.go
@@ -339,7 +339,8 @@ type SettingsStruct struct {
 	Dummy                     bool                  `json:"dummy"`
 	DummyChannel              string                `json:"dummyChannel"`
 	IgnoreFilters             bool                  `json:"ignoreFilters"`
-        PlexPlayer                bool                  `json:"plexPlayer"`	
+        PlexPlayer                bool                  `json:"plexPlayer"`
+        SystemChannelLimit        int                   `json:"systemChannelLimit"`
 }
 
 // LanguageUI : Sprache für das WebUI

--- a/src/struct-webserver.go
+++ b/src/struct-webserver.go
@@ -59,6 +59,7 @@ type RequestStruct struct {
 		DummyChannel             *string   `json:"dummyChannel,omitempty"`
 		IgnoreFilters            *bool     `json:"ignoreFilters,omitempty"`
                 PlexPlayer               *bool     `json:"plexPlayer,omitempty"`		
+                SystemChannelLimit       *int      `json:"systemChannelLimit,omitempty"`
 	} `json:"settings,omitempty"`
 
 	// Upload Logo

--- a/src/struct-webserver.go
+++ b/src/struct-webserver.go
@@ -58,6 +58,7 @@ type RequestStruct struct {
 		Dummy                    *bool     `json:"dummy,omitempty"`
 		DummyChannel             *string   `json:"dummyChannel,omitempty"`
 		IgnoreFilters            *bool     `json:"ignoreFilters,omitempty"`
+                PlexPlayer               *bool     `json:"plexPlayer,omitempty"`		
 	} `json:"settings,omitempty"`
 
 	// Upload Logo

--- a/src/system.go
+++ b/src/system.go
@@ -122,6 +122,7 @@ func loadSettings() (settings SettingsStruct, err error) {
 	dataMap["m3u"] = make(map[string]interface{})
 	dataMap["hdhr"] = make(map[string]interface{})
         defaults["plexPlayer"] = true
+        defaults["systemChannelLimit"] = 1000
 	defaults["api"] = false
 	defaults["authentication.api"] = false
 	defaults["authentication.m3u"] = false

--- a/src/system.go
+++ b/src/system.go
@@ -121,7 +121,7 @@ func loadSettings() (settings SettingsStruct, err error) {
 	dataMap["xmltv"] = make(map[string]interface{})
 	dataMap["m3u"] = make(map[string]interface{})
 	dataMap["hdhr"] = make(map[string]interface{})
-
+        defaults["plexPlayer"] = true
 	defaults["api"] = false
 	defaults["authentication.api"] = false
 	defaults["authentication.m3u"] = false

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -324,10 +324,32 @@ func Threadfin(w http.ResponseWriter, r *http.Request) {
 		setGlobalDomain(r.Host)
 	}
 
-	// XMLTV Datei
-	if strings.Contains(path, "xmltv/") {
+        // Verify security first and just once.
+        if strings.Contains(path, "xmltv/") {
+                requestType = "xml" }
+        if strings.Contains(path, "m3u/") {
+                requestType = "m3u" }
 
-		requestType = "xml"
+        err = urlAuth(r, requestType)
+            if err != nil {
+               ShowError(err, 000)
+               httpStatusError(w, r, 403)
+               return
+            }
+
+
+	// XMLTV Datei
+/*	if strings.Contains(path, "xmltv/") {
+
+		requestType = "xml"*/
+        if requestType == "xml"{
+/*               // verify security
+                err = urlAuth(r, requestType)
+                if err != nil {
+                      ShowError(err, 000)
+                      httpStatusError(w, r, 403)
+                      return
+                }*/
 
 		file = System.Folder.Data + getFilenameFromPath(path)
 
@@ -340,16 +362,18 @@ func Threadfin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// M3U Datei
-	if strings.Contains(path, "m3u/") {
+/*	if strings.Contains(path, "m3u/") {
 
-		requestType = "m3u"
+		requestType = "m3u"*/
 
-		err = urlAuth(r, requestType)
+	if requestType == "m3u"{
+
+/*		err = urlAuth(r, requestType)
 		if err != nil {
 			ShowError(err, 000)
 			httpStatusError(w, r, 403)
 			return
-		}
+		}*/
 
 		groupTitle = r.URL.Query().Get("group-title")
 

--- a/src/xepg.go
+++ b/src/xepg.go
@@ -308,9 +308,20 @@ func createXEPGMapping() {
 // XEPG Datenbank erstellen / aktualisieren
 func createXEPGDatabase() (err error) {
 
-	var allChannelNumbers = make([]float64, 0, System.UnfilteredChannelLimit)
+        // Changes ChannelLimit to allow more channels if the player/client is not Plex (Restricted to 480 Channels Max)
+        var ChannelLimit = System.PlexChannelLimit
+        if !Settings.PlexPlayer{
+               ChannelLimit = Settings.SystemChannelLimit
+           }
+
+/*	var allChannelNumbers = make([]float64, 0, System.UnfilteredChannelLimit)
 	Data.Cache.Streams.Active = make([]string, 0, System.UnfilteredChannelLimit)
 	Data.XEPG.Channels = make(map[string]interface{}, System.UnfilteredChannelLimit)
+*/
+        var allChannelNumbers = make([]float64, 0, ChannelLimit)
+        Data.Cache.Streams.Active = make([]string, 0, ChannelLimit)
+        Data.XEPG.Channels = make(map[string]interface{}, ChannelLimit)
+
 	Settings = SettingsStruct{}
 	Data.XEPG.Channels, err = loadJSONFileToMap(System.File.XEPG)
 	if err != nil {
@@ -378,7 +389,8 @@ func createXEPGDatabase() (err error) {
 	}
 
 	// Make a map of the db channels based on their previously downloaded attributes -- filename, group, title, etc
-	var xepgChannelsValuesMap = make(map[string]XEPGChannelStruct, System.UnfilteredChannelLimit)
+//	var xepgChannelsValuesMap = make(map[string]XEPGChannelStruct, System.UnfilteredChannelLimit)
+        var xepgChannelsValuesMap = make(map[string]XEPGChannelStruct, ChannelLimit)
 	for _, v := range Data.XEPG.Channels {
 		var channel XEPGChannelStruct
 		err = json.Unmarshal([]byte(mapToJSON(v)), &channel)


### PR DESCRIPTION
Adds 2 new Settings in settings.json file: 
PlexPlayer -> identifies if the client is Plex software or not
SystemChannelLimit -> sets a configurable limit un playlist lenght

If PlexPlayer equals **false**, changes the MaxChannelLimit from 480 to this new value configured in SystemChannelLimit. If PlexPlayer equals **true**, it will continue to work with the 480 channels limit. By default the settings will be: PlexPlayer = true, SystemChannelLimit = 1000 (not used due PlexPlayer value of true)

As for auth, version 1.2.9 now allows to download the xml without credentials every time is requested. This fix changes the order Threadfin uses to check for authentication, and fixes the issue.