### PR TITLE
M3U Parser performance optimization 

### DIFF
--- a/src/internal/m3u-parser/struct-safelist.go
+++ b/src/internal/m3u-parser/struct-safelist.go
@@ -1,0 +1,47 @@
+package m3u
+
+import (
+	"sync"
+)
+
+// SafeList is a concurrent-safe list that holds interface{} items.
+type SafeList struct {
+	mu    sync.RWMutex
+	items []interface{}
+}
+
+// Append adds an item to the list (write operation).
+func (s *SafeList) Append(item interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = append(s.items, item)
+}
+
+// Get returns an item from the list by index (read operation).
+func (s *SafeList) Get(index int) (interface{}, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if index < 0 || index >= len(s.items) {
+		return nil, false
+	}
+	return s.items[index], true
+}
+
+// Len returns the length of the list (read operation).
+func (s *SafeList) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.items)
+}
+
+// Contains checks if the list contains the specified item (read operation).
+func (s *SafeList) Contains(item interface{}) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, v := range s.items {
+		if v == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
I've been trying to setup Threadfin on my UnRaid NAS which has a relatively low-powered CPU and each time I would import my m3u file it would simply hang due to my m3u file having 263573 streams.
I did some testing on my development PC which has a beefier Intel i7 12000H (14 cores and 20 threads) and even for that it takes quite a bit of time to process the file. So I decided to see if I could optimize the process by introducing goroutines to run things in parallel.

Here are some before and after timings on my dev PC processing the 263573 streams 
Before:
```
D:\src\Threadfin\src\internal\m3u-parser>go test
Streams: 263573
PASS
ok      threadfin/src/internal/m3u-parser       203.084s
```
After:
```
D:\src\Threadfin\src\internal\m3u-parser>go test
Streams: 263573
PASS
ok      threadfin/src/internal/m3u-parser       3.664s
```

Tbh I haven't tested on my NAS yet but I'm hoping it will also benefit from these performance improvements