### PR TITLE
Fix #466 by allowing user and origin to be null

### DIFF
--- a/src/struct-webserver.go
+++ b/src/struct-webserver.go
@@ -42,8 +42,8 @@ type RequestStruct struct {
 		UDPxy                    *string   `json:"udpxy,omitempty"`
 		Update                   *[]string `json:"update,omitempty"`
 		UserAgent                *string   `json:"user.agent,omitempty"`
-		UserOrigin               string    `json:"user.origin"`
-		UserReferer              string    `json:"user.referer"`
+		UserOrigin               *string   `json:"user.origin"`
+		UserReferer              *string   `json:"user.referer"`
 		XepgReplaceMissingImages *bool     `json:"xepg.replace.missing.images,omitempty"`
 		XepgReplaceChannelTitle  *bool     `json:"xepg.replace.channel.title,omitempty"`
 		ThreadfinAutoUpdate      *bool     `json:"ThreadfinAutoUpdate,omitempty"`


### PR DESCRIPTION
#466 was happening any time that you changed one value and not the other. Because the model didn't default to null it'd get set to an empty string, which would look like a new value when a different field was saved.