### PR TITLE
Handle tall logos to keep rows a uniform height

### DIFF
--- a/html/css/base.css
+++ b/html/css/base.css
@@ -107,7 +107,7 @@ label {
 li {
   list-style-type: none;
   cursor: pointer;
-  transition: all 0.3;
+  transition: all 0.3s;
 }
 
 li:hover {

--- a/html/css/screen.css
+++ b/html/css/screen.css
@@ -304,9 +304,44 @@ tbody {
   max-width: 60px;
 }
 
+#content_table .logo-cell .imgWrap,
+#inactive_content_table .logo-cell .imgWrap {
+  width: 60px;
+  height: 50px;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  padding: 0;
+  box-sizing: border-box;
+  vertical-align: middle;
+}
+
+#content_table .logo-cell img,
+#inactive_content_table .logo-cell img {
+  width: 60px;
+  height: auto;
+  transition: all 0.3s ease;
+}
+
+#content_table .logo-cell .imgWrap:hover,
+#inactive_content_table .logo-cell .imgWrap:hover {
+  min-height: 50px;
+  height: auto;
+  overflow: visible;
+}
+
+#content_table .logo-cell .imgWrap:hover img,
+#inactive_content_table .logo-cell .imgWrap:hover img {
+  height: auto;
+  max-height: none;
+  width: 60px;
+}
+
 #content_table tr,
 #inactive_content_table tr {
-  border-left: solid 3px 444;
+  border-left: solid 3px #444;
   border-bottom: solid 1px #333;
   cursor: pointer;
 }
@@ -325,8 +360,8 @@ tbody {
 #content_table input[type=text],
 #inactive_content_table input[type=text] {
   width: 80%;
-  min-width: 35px;
-  max-width: 60px;
+  min-width: 60px;
+  max-width: 75px;
   border: 0px;
   background-color: #333;
   margin-left: 5px;
@@ -763,8 +798,12 @@ Sidebar
   cursor: pointer;
   border-radius: 5px;
   z-index: 1000;
+  border: 1px solid #222;
+  box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19);
+  transition: all .3s ease;
 }
 
 #back-to-top:hover {
   background-color: #555;
+  box-shadow: 0 8px 16px 0 rgba(0,0,0,0.4), 0 6px 20px 0 rgba(0,0,0,0.39)
 }

--- a/ts/menu_ts.ts
+++ b/ts/menu_ts.ts
@@ -444,6 +444,7 @@ class Content {
             cell.imageURL = data[key]["tvg-logo"]
             var td = cell.createCell()
             td.setAttribute('onclick', 'javascript: openPopUp("mapping", this)')
+            td.className = "logo-cell"
             td.id = key
 
             tr.appendChild(td)
@@ -591,6 +592,7 @@ class Content {
             cell.imageURL = data[key]["tvg-logo"]
             var td = cell.createCell()
             td.setAttribute('onclick', 'javascript: openPopUp("mapping", this)')
+            td.className = "logo-cell"
             td.id = key
 
             tr.appendChild(td)
@@ -756,12 +758,17 @@ class Cell {
           break
 
         case "IMG":
-          element = document.createElement(this.childType);
-          element.setAttribute("src", this.imageURL)
+          var imgElement: any
+          imgElement = document.createElement(this.childType);
+          imgElement.setAttribute("src", this.imageURL)
           if (this.imageURL != "") {
-            element.setAttribute("onerror", "javascript: this.onerror=null;this.src=''")
+            imgElement.setAttribute("onerror", "javascript: this.onerror=null;this.src=''")
             //onerror="this.onerror=null;this.src='missing.gif';"
           }
+          element = document.createElement("DIV");
+          element.className = "imgWrap";
+          element.appendChild(imgElement);
+
       }
 
       td.appendChild(element)
@@ -939,7 +946,7 @@ class ShowContent extends Content {
         break;
     }
 
-    // Tabelle erstellen (falls benötigt)
+    // Create table (if needed)
     var tableHeader: string[] = menuItems[this.menuID].tableHeader
     if (tableHeader.length > 0) {
       var wrapper = document.createElement("DIV")
@@ -952,7 +959,7 @@ class ShowContent extends Content {
       var header = this.createTableRow()
       table.appendChild(header)
 
-      // Kopfzeile der Tablle
+      // Table header
       tableHeader.forEach(element => {
         var cell: Cell = new Cell()
         cell.child = true
@@ -2794,7 +2801,7 @@ function donePopupData(dataType: string, idsStr: string) {
     }
 
     console.log(input["tvg-logo"]);
-    (document.getElementById(id).childNodes[2].firstChild as HTMLElement).setAttribute("src", input["tvg-logo"])
+    (document.getElementById(id).childNodes[2].firstChild.firstChild as HTMLElement).setAttribute("src", input["tvg-logo"])
 
 
   });


### PR DESCRIPTION
This is a very subjective style change, so feel free to decline it or let me know if you want something changed.  It's always bothered me that any tall logo causes rows to have different heights.  This change crops any tall logos, and then shows the full thing on hover of the logo.

It looks like this if you have a tall logo:
<img width="791" alt="image" src="https://github.com/user-attachments/assets/28bd58e5-3d97-40bc-8461-7d1e7e4357ea" />

And like this if you hover over the logo:
<img width="783" alt="image" src="https://github.com/user-attachments/assets/f25b2c0f-bf0f-4444-888e-8e71298349f2" />
