### PR TITLE
process bindIpAddress flag properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ threadfin
 vendor/
 .DS_Store
 threadfin.exe
+.idea/**

--- a/threadfin.go
+++ b/threadfin.go
@@ -80,9 +80,6 @@ func main() {
 	system.GitHub = GitHub
 	system.Name = Name
 	system.Version = strings.Join(build[0:len(build)-1], ".")
-	if bindIpAddress != nil && len(*bindIpAddress) > 0 {
-		system.IPAddress = *bindIpAddress
-	}
 
 	// Panic !!!
 	defer func() {
@@ -149,6 +146,10 @@ func main() {
 	// Webserver Port
 	if len(*port) > 0 {
 		system.Flag.Port = *port
+	}
+
+	if bindIpAddress != nil && len(*bindIpAddress) > 0 {
+		system.IPAddress = *bindIpAddress
 	}
 
 	// Branch


### PR DESCRIPTION
Trying to debug some things on my end I noticed that the bindIpAddress check happens before the flag.Parse() so it'll never work. This fixes that. Although after doing this I still had issues and this flag really does nothing since the bind IP address comes from the settings.json during the actual runtime creation of the webserver.