### PR TITLE
Add support for nscd for johnvansickle ffmpeg static builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ RUN apt-get update && \
     curl \
     ffmpeg \
     vlc \
-    tzdata && \
+    tzdata \
+    nscd && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p $THREADFIN_BIN $THREADFIN_CONF $THREADFIN_TEMP $THREADFIN_HOME/cache && \
@@ -86,4 +87,4 @@ VOLUME $THREADFIN_TEMP
 
 EXPOSE $THREADFIN_PORT
 
-ENTRYPOINT ["sh", "-c", "${THREADFIN_BIN}/threadfin -port=${THREADFIN_PORT} -bind=${THREADFIN_BIND_IP_ADDRESS} -config=${THREADFIN_CONF} -debug=${THREADFIN_DEBUG}"]
+ENTRYPOINT ["sh", "-c", "${THREADFIN_BIN}/threadfin -port=${THREADFIN_PORT} -bind=${THREADFIN_BIND_IP_ADDRESS} -config=${THREADFIN_CONF} -debug=${THREADFIN_DEBUG} && nscd"]


### PR DESCRIPTION
Feel free to reject this pull request, however it aims to address the following issue:

The version of ffmpeg that the Threadfin docker container ships with is buggy with certain types of streams. I've had to resort to using some older builds of FFmpeg, eg 4.4.1 to get stable streaming on certain channels.

FFmpeg has seen a bit of a regression in recent times, so I simply volume map in some old static builds into the container. The FFmpeg official site links to "johnvansickle" binary builds: https://johnvansickle.com/ffmpeg/. Unfortunately these builds require 'nscd' to be available on the system in order to perform DNS resolution. If nscd is not available, then a segmentation fault is experienced.

This pull request simply helps those wanting to run these official ffmpeg builds inside the container.