### PR TITLE
Docker mods

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+Dockerfile.arm
+LICENSE
+READMD-DEV.md
+README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            BASE_OS=ubuntu:24.04
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: fyb3roptik/threadfin:latest,fyb3roptik/threadfin:${{ github.ref_name }}
@@ -102,7 +104,7 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: |
-            USE_NVIDIA=1
+            BASE_OS=nvidia/cuda:12.8.0-base-ubuntu24.04
           push: true
           platforms: linux/amd64,linux/arm64
           tags: fyb3roptik/threadfin:latest-nvidia,fyb3roptik/threadfin:${{ github.ref_name }}-nvidia

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
+# Build ARG for final image base
+ARG BASE_OS=ubuntu:24.04
+
 # First stage. Building a binary
 # -----------------------------------------------------------------------------
-ARG USE_NVIDIA
-
 FROM golang:1.23-bullseye AS builder
 
 WORKDIR /app
@@ -18,14 +19,8 @@ RUN CGO_ENABLED=0 go build -mod=mod -ldflags="-s -w" -trimpath -o threadfin thre
 
 # Second stage. Creating a minimal image
 # -----------------------------------------------------------------------------
-ARG USE_NVIDIA
-FROM ubuntu:24.04 AS standard
-FROM nvidia/cuda:12.8.0-base-ubuntu24.04 AS nvidia
-FROM standard AS final
-FROM nvidia AS final-nvidia
-
-ARG USE_NVIDIA
-FROM final${USE_NVIDIA:+-nvidia}
+ARG BASE_OS
+FROM ${BASE_OS}
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Updated docker build to simplify the base images with a build ARG (BASE_OS). Default is ubuntu:24.4. Added .dockerignore file to avoid recompiling the when modifying Dockerfiles.