### PR TITLE
Fixed issue where tvg-id had a value of (no tvg-id)

### DIFF
--- a/src/internal/m3u-parser/xteve_m3uParser.go
+++ b/src/internal/m3u-parser/xteve_m3uParser.go
@@ -75,8 +75,7 @@ func MakeInterfaceFromM3U(byteStream []byte) (allChannels []interface{}, err err
 
 			// Only generate a new tvg-id if it's missing, blank, or (no tvg-id)
 			if stream["tvg-id"] == "" || stream["tvg-id"] == "(no tvg-id)" {
-				// Use MD5 hash of both channel name and URL to ensure uniqueness
-				hash := md5.Sum([]byte(channelName + stream["url"]))
+				hash := md5.Sum([]byte(stream["url"]))
 				stream["tvg-id"] = fmt.Sprintf("threadfin-%x", hash)
 			}
 

--- a/src/internal/m3u-parser/xteve_m3uParser.go
+++ b/src/internal/m3u-parser/xteve_m3uParser.go
@@ -73,10 +73,10 @@ func MakeInterfaceFromM3U(byteStream []byte) (allChannels []interface{}, err err
 				}
 			}
 
-			// Only generate a new tvg-id if it's missing or blank
-			if stream["tvg-id"] == "" {
-				// Use MD5 hash of the URL as the tvg-id
-				hash := md5.Sum([]byte(stream["url"]))
+			// Only generate a new tvg-id if it's missing, blank, or (no tvg-id)
+			if stream["tvg-id"] == "" || stream["tvg-id"] == "(no tvg-id)" {
+				// Use MD5 hash of both channel name and URL to ensure uniqueness
+				hash := md5.Sum([]byte(channelName + stream["url"]))
 				stream["tvg-id"] = fmt.Sprintf("threadfin-%x", hash)
 			}
 


### PR DESCRIPTION
Added a check where the tvg-id had a value of "(no tvg-id)" which caused streams with the same hash value. 

The issue might be caused by either m3u4u or the specific provider.