### PR TITLE
Add -re to default FFmpeg options to prevent live-stream replay loops

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -65,7 +65,7 @@ func Init() (err error) {
 	System.Compatibility = "0.1.0"
 
 	// FFmpeg Default Einstellungen
-	System.FFmpeg.DefaultOptions = "-hide_banner -loglevel error -analyzeduration 1000000 -probesize 1000000 -i [URL] -map 0:v -map 0:a:0 -c:v copy -c:a aac -b:a 192k -ac 2 -c:s copy -f mpegts -fflags +genpts -movflags +faststart -copyts pipe:1"
+	System.FFmpeg.DefaultOptions = "-re -hide_banner -loglevel error -analyzeduration 1000000 -probesize 1000000 -i [URL] -map 0:v -map 0:a:0 -c:v copy -c:a aac -b:a 192k -ac 2 -c:s copy -f mpegts -fflags +genpts -movflags +faststart -copyts pipe:1"
 	System.VLC.DefaultOptions = "-I dummy [URL] --sout #std{mux=ts,access=file,dst=-}"
 
 	// Default Logeinträge, wird später von denen aus der settings.json überschrieben. Muss gemacht werden, damit die ersten Einträge auch im Log (webUI aangezeigt werden)


### PR DESCRIPTION
# PR: Add `-re` to default FFmpeg options to prevent live-stream replay loops

**Branch:** `fix/default-ffmpeg-re-flag` · **Change:** one line in `src/config.go`

## Summary

The default `System.FFmpeg.DefaultOptions` has no `-re`. When buffering a live HLS source that
serves a deep sliding window, ffmpeg without `-re` reads the playlist **faster than realtime**,
races ahead of the live edge, and on a source stall **re-reads/replays already-served segments**.
This surfaces as a **backward PTS discontinuity** in Threadfin's output, which downstream players
(Plex Live TV) re-monotonize — so the **playback clock keeps advancing while the picture silently
replays the last ~1–2 minutes**, often wedging into a permanent loop until the client restarts.

This is the same class of problem reported in #106 ("stream reloads ~1 min when using the ffmpeg
buffer" — community fix is `-re`) and #224 ("streams looping in Plex, sometimes irrecoverably").

## The change

```diff
- System.FFmpeg.DefaultOptions = "-hide_banner -loglevel error ... -copyts pipe:1"
+ System.FFmpeg.DefaultOptions = "-re -hide_banner -loglevel error ... -copyts pipe:1"
```

`-re` paces input to the stream's native rate, so ffmpeg tracks the live edge and has no backlog
to replay on recovery.

**Tradeoff:** marginally slower channel changes (the initial buffer fills at 1× instead of as fast
as the network allows).

## Evidence (captured against a real deep-window HLS source)

Reading Threadfin's own output directly, ffmpeg logged a periodic backward jump:

```
timestamp discontinuity (stream id=256): -97440000, new offset= 194880000
```

`-97.44s` backward, accumulated offset `194.88s = 2 × 97.44` ⇒ a repeating ~97s replay. The
upstream source was verified clean (live edge advancing normally). Plex over-produced segments at
~1.8× realtime, consistent with a faster-than-realtime read of the window.

**Before/after:** a plain reader of Threadfin's output stalled at ~88s and logged the −97.44s
discontinuity; after adding `-re`, the same reader ran 260s with **no stall and zero
discontinuity**.

## Notes

- Only the ffmpeg default is changed; existing users with custom `ffmpeg.options` are unaffected
  until they reset to default (they can add `-re` themselves).
- The VLC default is left untouched (`-re` is ffmpeg-specific).
