### PR TITLE
Document ffmpeg reconnect options as opt-in for unstable HTTP sources

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -65,6 +65,18 @@ func Init() (err error) {
 	System.Compatibility = "0.1.0"
 
 	// FFmpeg Default Einstellungen
+	// Optional: some unstable HTTP sources benefit from adding ffmpeg's HTTP
+	// reconnect options before "-i [URL]", e.g.:
+	//   -reconnect 1 -reconnect_streamed 1 -reconnect_on_network_error 1 -reconnect_on_http_error 4xx,5xx -reconnect_delay_max 2
+	// These make ffmpeg reconnect inside the same process/output timeline
+	// instead of exiting and letting the buffer layer restart the stream.
+	// This is NOT a safe default: some servers replay a few seconds of
+	// backlog on every new connection, and with in-process reconnect that
+	// backlog gets spliced into the continuous timeline, showing up as a
+	// visible loop/jump-back. Without the flags, a dropped connection is a
+	// clean (if slightly abrupt) restart instead. Add the flags manually
+	// in Settings > FFmpeg options only if your source is confirmed not to
+	// replay backlog on reconnect.
 	System.FFmpeg.DefaultOptions = "-hide_banner -loglevel error -analyzeduration 1000000 -probesize 1000000 -i [URL] -map 0:v -map 0:a:0 -c:v copy -c:a aac -b:a 192k -ac 2 -c:s copy -f mpegts -fflags +genpts -movflags +faststart -copyts pipe:1"
 	System.VLC.DefaultOptions = "-I dummy [URL] --sout #std{mux=ts,access=file,dst=-}"
 


### PR DESCRIPTION
Title: Document ffmpeg reconnect options as opt-in for unstable HTTP sources

## Problem

Many IPTV providers periodically tear down long-lived HTTP stream connections (session rotation, load-balancer timeouts, CDN failover). With the current default ffmpeg options there is no in-process reconnect: when the provider closes the connection, ffmpeg exits, the whole buffer pipeline restarts, and client-side segmenters (Plex/Jellyfin live TV) render the discontinuity as a freeze or a short cut every time it happens.

ffmpeg's HTTP reconnect options address that class of drop:

```
-reconnect 1 -reconnect_streamed 1 -reconnect_on_network_error 1 -reconnect_on_http_error 4xx,5xx -reconnect_delay_max 2
```

With these, ffmpeg re-establishes the connection inside the same process, so the output timeline stays continuous instead of the buffer layer restarting the stream.

## Field caveat (why this is opt-in, not a default)

Testing against a real provider surfaced a worse failure mode on some servers: **on every new connection the server replays the last ~30 seconds of content as a catch-up backlog.** With in-process reconnect, that replay gets spliced into the same continuous output timeline — the client visibly loops or jumps back over content it already played, on every reconnect.

Without the reconnect flags, a dropped connection makes ffmpeg exit and the buffer layer restarts the stream: a brief cut, but a clean timeline. On servers with backlog-replay behavior, that's the smaller failure of the two.

Since the right choice depends on how a given upstream server behaves after a dropped connection, and there's no reliable way to detect that ahead of time, this should not be an unconditional default for every install.

## Change (revised from the original proposal)

The original version of this PR added the reconnect flags directly to `System.FFmpeg.DefaultOptions`. This revision **does not change the default** — `System.FFmpeg.DefaultOptions` is left exactly as it ships today. Instead, `src/config.go` gets a comment next to the default documenting the reconnect flags, when to add them, and the backlog-replay caveat above, so operators can opt in deliberately after confirming their source doesn't replay backlog on reconnect (Settings > FFmpeg options).

## Effect on existing/new installs

None — this is a documentation-only change (a code comment). No behavior changes for any install, new or existing.

Related: #659 touches the same default string; unaffected by this change since the default itself is untouched here.
