### PR TITLE
Fix failover blackout: continue segment numbering across backup switches

### DIFF
--- a/src/buffer.go
+++ b/src/buffer.go
@@ -1026,6 +1026,7 @@ func thirdPartyBuffer(streamID int, playlistID string, useBackup bool, backupNum
 		var playlist = p.(Playlist)
 		var debug, path, options, bufferType string
 		var tmpSegment = 1
+		var startSegment = 1
 		var bufferSize = Settings.BufferSize * 1024
 		var stream = playlist.Streams[streamID]
 		var buf bytes.Buffer
@@ -1104,8 +1105,31 @@ func thirdPartyBuffer(streamID int, playlistID string, useBackup bool, backupNum
 
 		}
 
-		if err := bufferVFS.RemoveAll(getPlatformPath(tmpFolder)); err != nil {
-			ShowError(err, 4005)
+		// FAILOVER FIX (2026-08-19): on a backup switch, KEEP the buffer
+		// folder and continue segment numbering after the highest existing
+		// file. Wiping the folder and restarting at 1.ts reissued filenames
+		// a connected client had already been served; getBufTmpFiles skips
+		// known names, so the client received nothing until the backup had
+		// re-streamed the client's entire watched history in real time -
+		// a blackout proportional to how long they had been watching
+		// (measured: 157s watched -> >240s black, while a fresh client on
+		// the same channel got its first byte in 5.7s).
+		var keepFolder = false
+		if useBackup {
+			if files, errDir := bufferVFS.ReadDir(getPlatformPath(tmpFolder)); errDir == nil {
+				keepFolder = true
+				for _, file := range files {
+					if id, errAtoi := strconv.Atoi(strings.TrimSuffix(file.Name(), ".ts")); errAtoi == nil && id >= tmpSegment {
+						tmpSegment = id + 1
+					}
+				}
+				startSegment = tmpSegment
+			}
+		}
+		if !keepFolder {
+			if err := bufferVFS.RemoveAll(getPlatformPath(tmpFolder)); err != nil {
+				ShowError(err, 4005)
+			}
 		}
 
 		err := checkVFSFolder(tmpFolder, bufferVFS)
@@ -1289,7 +1313,7 @@ func thirdPartyBuffer(streamID int, playlistID string, useBackup bool, backupNum
 
 			select {
 			case timeout := <-t:
-				if timeout >= 20 && tmpSegment == 1 {
+				if timeout >= 20 && tmpSegment == startSegment {
 					cmd.Process.Kill()
 					err = errors.New("Timeout")
 					ShowError(err, 4006)
@@ -1333,7 +1357,7 @@ func thirdPartyBuffer(streamID int, playlistID string, useBackup bool, backupNum
 
 			if fileSize >= bufferSize/2 {
 
-				if tmpSegment == 1 && !stream.Status {
+				if tmpSegment == startSegment && !stream.Status {
 					close(t)
 					close(streamStatus)
 					showInfo(fmt.Sprintf("Streaming Status:Buffering data from %s", bufferType))


### PR DESCRIPTION
## The bug

On a backup switch, `thirdPartyBuffer()` wipes the buffer folder and restarts segment names at `1.ts`. But the client-serving loop tracks segments it has already sent **by filename** (`stream.OldSegments` in `getBufTmpFiles()`), and skips any name on that list. After a failover, every segment the new source writes (`1.ts, 2.ts, ...`) is a name the connected client has already seen — so it is silently discarded.

**The result: a connected client receives nothing until the backup has re-streamed the client's entire watched history in real time.** The blackout grows linearly with how long the viewer had been watching. Someone 2 hours into a stream is blacked out for hours after a "successful" failover, while the log shows the backup running fine.

## Measured (on 1.2.37, ffmpeg buffer, `storeBufferInRAM`)

* A client 157 s into a stream received **zero bytes for 240+ s** after its source died, even though the backup was delivering.
* A fresh client that connected right after the kill (empty `OldSegments`) got its **first byte in 5.7 s** from the same backup on the same channel.
* After this patch: the surviving client received bytes **within 1 s** of the backup producing data.

## The fix

When `useBackup` is set and the buffer folder exists, keep the folder and continue segment numbering after the highest existing file, instead of `RemoveAll` + restart at 1. The already-served names are never reissued, so connected clients ride the switch seamlessly.

Two comparisons that used the literal `1` now compare against the run's **starting** segment (`startSegment`):
* the 20 s no-data bailout (`timeout >= 20 && tmpSegment == startSegment`) — so a dead backup still cascades to the next one exactly as before;
* the one-shot "Buffering data" status flip / log-verbosity switch.

First-run behavior (no `useBackup`) is unchanged: same wipe, same numbering, `startSegment == 1`.

## Notes

* If the folder unexpectedly does not exist on a backup switch, the code falls back to the original wipe-and-recreate path.
* `strconv`/`strings` were already imported.
* Verified live on two Threadfin instances (120-channel and 56-channel lineups) by SIGTERM-ing the serving ffmpeg under a watching client.