### PR TITLE
Don't delete XEPG channels after a single missed update

### DIFF
--- a/src/struct-system.go
+++ b/src/struct-system.go
@@ -218,6 +218,13 @@ type XEPGChannelStruct struct {
 	BackupChannel2     *BackupStream `json:"backup_channel_2"`
 	BackupChannel3     *BackupStream `json:"backup_channel_3"`
 	ChannelUniqueID    string        `json:"channelUniqueID"`
+
+	// MissingCount counts how many consecutive updates this channel has been absent from
+	// its provider. cleanupXEPG removes the channel only once this reaches
+	// xepgMissingLimit, so that a provider which briefly under-reports cannot destroy a
+	// valid mapping on a single bad poll. Omitted when zero, so existing xepg.json files
+	// stay byte-identical until a channel actually goes missing.
+	MissingCount int `json:"x-missing-count,omitempty"`
 }
 
 // M3UChannelStructXEPG : M3U Struktur für XEPG

--- a/src/xepg.go
+++ b/src/xepg.go
@@ -22,6 +22,16 @@ import (
 	_ "time/tzdata"
 )
 
+// xepgMissingLimit is how many consecutive updates a channel must be absent from its
+// provider before cleanupXEPG removes it from the XEPG database.
+//
+// It exists because "absent from this one poll" and "gone for good" are not the same
+// thing. Providers under-report transiently: an HTTP 200 carrying a truncated list, a
+// refresh that races the provider's own scheduled rebuild, a proxy hiccup. Deleting on
+// the first miss turns any of those into permanent, silent loss of hand-made guide
+// mappings and channel numbers that the M3U cannot regenerate.
+const xepgMissingLimit = 3
+
 // Provider XMLTV Datei überprüfen
 func checkXMLCompatibility(id string, body []byte) (err error) {
 
@@ -1779,11 +1789,41 @@ func cleanupXEPG() {
 			m3uChannelHash := hex.EncodeToString(hash[:])
 
 			if indexOfString(m3uChannelHash, Data.Cache.Streams.Active) == -1 {
-				delete(Data.XEPG.Channels, id)
+
+				// Absent from this update. Do not delete on the first miss -- see
+				// xepgMissingLimit. Count it instead, and only remove the channel once it
+				// has been missing for that many updates in a row.
+				xepgChannel.MissingCount++
+
+				if xepgChannel.MissingCount >= xepgMissingLimit {
+
+					showInfo(fmt.Sprintf("XEPG:Removing channel '%s', absent from its provider for %d consecutive updates", xepgChannel.XName, xepgChannel.MissingCount))
+					delete(Data.XEPG.Channels, id)
+
+				} else {
+
+					showInfo(fmt.Sprintf("XEPG:Keeping channel '%s', absent from its provider (%d/%d) - not removing yet", xepgChannel.XName, xepgChannel.MissingCount, xepgMissingLimit))
+					Data.XEPG.Channels[id] = xepgChannel
+
+					if xepgChannel.XActive && !xepgChannel.XHideChannel {
+						Data.XEPG.XEPGCount++
+					}
+
+				}
+
 			} else {
+
+				// Present again. Clear any earlier miss, so that isolated blips spread
+				// over months cannot accumulate and eventually trip the limit.
+				if xepgChannel.MissingCount != 0 {
+					xepgChannel.MissingCount = 0
+					Data.XEPG.Channels[id] = xepgChannel
+				}
+
 				if xepgChannel.XActive && !xepgChannel.XHideChannel {
 					Data.XEPG.XEPGCount++
 				}
+
 			}
 
 			if indexOfString(xepgChannel.FileM3UID, sourceIDs) == -1 {


### PR DESCRIPTION
## The problem

`cleanupXEPG()` deletes any XEPG channel whose key is missing from the active stream list built during the current update:

```go
if indexOfString(m3uChannelHash, Data.Cache.Streams.Active) == -1 {
    delete(Data.XEPG.Channels, id)
}
```

This treats *"absent from this one poll"* as *"gone for good"*. Those are not the same thing. Providers under-report transiently — an HTTP 200 carrying a truncated list, a refresh that races the provider's own scheduled rebuild, a proxy hiccup — and none of those are distinguishable here from a channel the user actually removed.

The consequence is **silent, unrecoverable data loss**. The XEPG entry holds hand-made XMLTV mappings, channel numbers and per-channel settings that the M3U cannot regenerate, so once it is deleted the user has to rebuild it by hand and downstream clients (Plex/Jellyfin/Emby) lose the channel. Nothing warns them — the deletion isn't logged, and the next update just reports a smaller `XEPG Channels:` count.

Note this fires even when the download **succeeded**. The existing "keep the older file on download failure" path in `getProviderData` is a good protection, but it only covers a *failed* fetch, not a successful one that happens to be short.

## Evidence

A provider intermittently served 7 of its 8 channels on a successful refresh — HTTP 200, no download error, `Save File:` logged normally:

```
00:00:22  Active streams:  33      <- normally 34
00:00:23  XEPG:            Cleanup database
00:00:23  XEPG Channels:   24      <- normally 25
```

The same channel was lost on roughly half of the scheduled updates, deterministically, with nothing wrong in the configuration. Recovery each time meant restoring `xepg.json` from a backup.

## The fix

Count consecutive misses instead of deleting on the first one. A channel is removed only after it has been absent for `xepgMissingLimit` (3) updates in a row; seeing it again resets the counter, so isolated blips spread over months cannot accumulate and trip the limit.

Channels genuinely removed upstream still disappear — three updates later instead of one. Both outcomes are now logged, where previously the deletion was silent.

The separate removal of channels whose provider no longer exists in the settings is deliberately left alone: that reflects an explicit user action, not a transient failure.

## Compatibility

The counter lives in a new `MissingCount` field tagged `omitempty`, so:

- existing `xepg.json` files are byte-identical until a channel actually goes missing
- older builds reading a newer file simply ignore the unknown key
- no migration, no settings change, no UI change

## Testing

- `go build -mod=mod ./...` — clean
- `go vet -mod=mod ./src/...` — no new findings (the 5 it reports are pre-existing, in `system.go`, `maintenance.go` and `webserver.go`, none in the files touched here)
- `go build -mod=mod -o threadfin .` — links, 14 MB binary
- `gofmt -l src/xepg.go` — clean

Two pre-existing repo issues showed up while building and are **not** addressed here, to keep the diff focused:

- `vendor/modules.txt` is out of sync with `go.mod`, so builds need `-mod=mod` (or `go mod vendor`)
- `src/struct-system.go:340` (`ExcludeStreamHttps`) is indented with spaces rather than a tab, so `gofmt -l` flags that file on `main` already

Happy to adjust the threshold, make it configurable, or split the logging differently if you'd prefer.
