### PR TITLE
Fix silent channel loss from randomised filter evaluation order

### DIFF
--- a/src/data.go
+++ b/src/data.go
@@ -753,8 +753,19 @@ func createFilterRules() (err error) {
 	Data.Filter = nil
 	var dataFilter Filter
 
-	for _, f := range Settings.Filter {
+	// Settings.Filter is a map, and Go randomises map iteration order. Ranging over it
+	// directly left Data.Filter in a different order on every rebuild, so which filter got
+	// to claim a given stream changed from one scan to the next. Sort by the filter ID the
+	// UI assigns so evaluation order is stable and matches the order the user sees.
+	var filterIDs = make([]int64, 0, len(Settings.Filter))
+	for id := range Settings.Filter {
+		filterIDs = append(filterIDs, id)
+	}
+	sort.Slice(filterIDs, func(i, j int) bool { return filterIDs[i] < filterIDs[j] })
 
+	for _, id := range filterIDs {
+
+		var f = Settings.Filter[id]
 		var filter FilterStruct
 
 		var exclude, include string

--- a/src/m3u.go
+++ b/src/m3u.go
@@ -118,6 +118,11 @@ func filterThisStream(s interface{}) (status bool, liveEvent bool) {
 
 		case "custom-filter":
 			search = streamValues
+			// Note: a rule consisting only of {include} / !{exclude} groups is stripped to
+			// "" above, and strings.Contains(s, "") is always true - so such a filter matches
+			// every stream and lets its conditions decide. That is the intended behaviour,
+			// but it is only safe because a failed condition now falls through to the next
+			// filter instead of rejecting the stream outright.
 			if strings.Contains(search, filter.Rule) {
 				match = true
 			}
@@ -125,17 +130,21 @@ func filterThisStream(s interface{}) (status bool, liveEvent bool) {
 
 		if match == true {
 
+			// A failed condition means THIS filter does not want the stream - it does not
+			// mean no other filter may have it. Returning here ended the whole loop, so a
+			// stream was silently dropped whenever a filter it did not belong to happened
+			// to be evaluated before the one it did.
 			if len(exclude) > 0 {
 				var status = checkConditions(search, exclude, "exclude")
 				if status == false {
-					return false, liveEvent
+					continue
 				}
 			}
 
 			if len(include) > 0 {
 				var status = checkConditions(search, include, "include")
 				if status == false {
-					return false, liveEvent
+					continue
 				}
 			}
 


### PR DESCRIPTION
XEPG channel mappings disappear on their own, with no configuration change and no error in the log. I lost ErsatzTV channels out of the Plex guide repeatedly — sometimes one channel, sometimes seven — and it always looked nondeterministic. It is, and this is why.

## Three things combine

**1. `filterThisStream()` lets one filter veto every other filter.** When a filter matches a stream but rejects it on an `{include}` / `!{exclude}` condition, the function `return false`s — ending the whole loop. The stream never reaches the filter it actually belongs to, and is silently deactivated.

**2. Filter evaluation order is randomised on every scan.** `createFilterRules()` builds `Data.Filter` with `for _, f := range Settings.Filter`, and `Settings.Filter` is a `map[int64]interface{}`. Go randomises map iteration order, and nothing sorts it afterwards. So which filter gets first claim on a stream changes from one `buildDatabaseDVR()` to the next — same config, same sources, different result.

**3. A conditions-only `custom-filter` matches everything.** A rule like `{16,21,31}` is entirely consumed by the include-extraction regex, leaving `filter.Rule == ""` — and `strings.Contains(s, "")` is always true in Go. That filter therefore matches *every* stream and falls straight through to its include check.

Put together: a conditions-only custom-filter that happens to sort before your other filters will claim every stream, reject the ones failing its include list, and — because of #1 — drop them entirely instead of letting their real filter have them.

The loss is **permanent, not transient**: `cleanupXEPG()` deletes any XEPG channel missing from `Data.Cache.Streams.Active`, so the mapping is erased from `xepg.json` and the channel vanishes from the guide. Nothing crashes, other channels keep working, and `/lineup.json` answers normally — just with fewer entries. It is very easy to miss.

## Reproduction

Three filters — `24x7` (group-title), `ErsatzTV` (group-title), `OTA` (custom-filter, rule `{16,21,31,32,33,47}`) — over a fixed 118-stream playlist, 8 of them ErsatzTV. I ported `parsePlaylist` + `filterThisStream` and enumerated all six orderings:

| Filter order | Active streams | ErsatzTV surviving |
|---|---|---|
| 24x7 › ErsatzTV › OTA | 34 | 8 |
| ErsatzTV › 24x7 › OTA | 34 | 8 |
| ErsatzTV › OTA › 24x7 | 33 | 7 |
| 24x7 › OTA › ErsatzTV | 28 | 2 |
| OTA › 24x7 › ErsatzTV | 27 | 1 |
| OTA › ErsatzTV › 24x7 | 27 | 1 |

Four of six orderings lose channels — a 67% chance per update cycle. Every one of these counts matched what I saw in production, including which specific channels went. One channel survived every single cull, which looked like a clue but was pure coincidence: its `tvg-id` contains `47`, one of the OTA include keys, so it passed that filter's check no matter when it ran.

Worth stressing that the source was never at fault. I probed the upstream m3u every minute across the update window: HTTP 200, byte-identical, all 8 channels present. `All streams: 118` is logged identically on culled and healthy cycles — only `Active streams` moves.

## The change

- `filterThisStream()`: `continue` instead of `return false` on a failed condition, so a filter that does not want a stream simply passes on it.
- `createFilterRules()`: sort the filter IDs before building `Data.Filter`, so evaluation order is deterministic and matches the order shown in the UI.

Small enough to read in one sitting, and it leaves the "source no longer in settings" delete alone — that one is an explicit user action.

## Verification

Built against `6b9c0cc` in `golang:1.22`: `go build -mod=mod ./...` passes and the binary links (14 MB). `go vet` and `gofmt -l` output is **byte-identical to unpatched main** — 6 and 11 pre-existing findings respectively, none introduced here. (Note `-mod=mod` is required because `vendor/modules.txt` is out of sync with `go.mod` on main; unrelated to this change.)

## Workaround without patching

If you are hitting this and cannot run a patched build, give the conditions-only custom-filter a base rule that its own conditions will match, so it stops matching every stream. In my case adding a token common to the affected channels to the include list was enough — verified to produce an identical active set across all six orderings.

## Relation to #663

#663 adds a consecutive-miss counter to `cleanupXEPG()`. I filed it before I had the real cause and it treats the symptom — worth keeping as defence in depth, since it also covers a genuinely flaky source, but this PR is the actual fix. Happy to close #663, rebase either one, or split this into two commits — whatever suits.
